### PR TITLE
Just two small fixes

### DIFF
--- a/src/spam/distance_matrix.cpp
+++ b/src/spam/distance_matrix.cpp
@@ -185,7 +185,7 @@ std::ostream& operator<<(std::ostream& os, distance_matrix const& matrix)
             os << sequence.name() << ' ';
         }
 		for (int j = 0; j < matrix.size(); j++){
-			os << distances[j] << ' ';
+			os << "  " << distances[j];
 		}
 		os << "\n";
 	}

--- a/src/spam/distance_matrix.cpp
+++ b/src/spam/distance_matrix.cpp
@@ -1,6 +1,7 @@
 #include "distance_matrix.hpp"
 
 #include <thread>
+#include <iomanip>
 
 #include <fmt/format.h>
 
@@ -171,19 +172,7 @@ std::ostream& operator<<(std::ostream& os, distance_matrix const& matrix)
 	os << matrix.size() << std::endl;
 	for (int i = 0; i < matrix.size(); i++) {
         auto const& [sequence, distances] = matrix.column(i);
-        auto length = sequence.name().length();
-        if (length < 10) {
-            os << sequence.name();
-            for (auto i = length; length < 10; ++length) {
-                os << ' ';
-            }
-        }
-        else if (length > 10) {
-            os << sequence.name().substr(0, 10);
-        }
-        else {
-            os << sequence.name() << ' ';
-        }
+        os << std::setw(10) << std::left << sequence.name();
 		for (int j = 0; j < matrix.size(); j++){
 			os << "  " << distances[j];
 		}

--- a/src/spam/sequence.cpp
+++ b/src/spam/sequence.cpp
@@ -10,7 +10,13 @@ namespace spam {
 auto operator>>(std::istream& is, assembled_sequence& seq)
     -> std::istream&
 {
-    std::getline(is, seq.name);
+    std::string name;
+    std::getline(is, name);
+    auto p = std::find_if(name.begin(), name.end(), [](const char c) { return isspace(c); });
+    if (p != name.end()) {
+        name.erase(p, name.end());
+    }
+    seq.name = std::move(name);
     std::string nucleotides;
     std::getline(is, nucleotides, '>');
     nucleotides.erase(std::remove_if(nucleotides.begin(), nucleotides.end(),


### PR DESCRIPTION
If a fasta file contains a comment or a long name the distance matrices are broken. Here are two fixes for that.
Best,
Fabian